### PR TITLE
ci: roll out jido workflows v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -10,16 +11,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-jobs:
-  lint:
-    name: Lint
-    uses: agentjido/github-actions/.github/workflows/elixir-lint.yml@v3
-    secrets: inherit
+permissions:
+  actions: read
+  contents: read
 
-  test:
-    name: Test
-    uses: agentjido/github-actions/.github/workflows/elixir-test.yml@v3
+jobs:
+  ci:
+    name: CI
+    uses: agentjido/github-actions/.github/workflows/jido-ci.yml@v4
+    secrets: inherit
     with:
       otp_versions: '["27", "28"]'
       elixir_versions: '["1.18", "1.19"]'
+      experimental_compile_elixir_versions: '["v1.20.0-rc.4"]'
+      experimental_compile_otp_versions: '["28.4.1"]'
+      experimental_compile_otp_name: '28'
+      docs_command: mix docs -f html
       test_command: mix test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,25 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
+      operation:
+        description: "Release operation: auto, prepare, or publish"
+        required: false
+        type: choice
+        default: auto
+        options:
+          - auto
+          - prepare
+          - publish
+      tag_name:
+        description: "Optional v-prefixed tag for publish simulation"
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: "Dry run (no git push, no tag, no GitHub release, no Hex publish)"
         required: false
@@ -13,16 +30,30 @@ on:
         required: false
         type: boolean
         default: false
+      skip_tests:
+        description: "Skip tests before release"
+        required: false
+        type: boolean
+        default: false
+      version_override:
+        description: "Optional bare SemVer override (for example 1.2.3, not v1.2.3)"
+        required: false
+        type: string
+        default: ""
 
 permissions:
+  actions: read
   contents: write
 
 jobs:
   release:
     name: Release
-    uses: agentjido/github-actions/.github/workflows/elixir-release.yml@v3
+    uses: agentjido/github-actions/.github/workflows/jido-release.yml@v4
     with:
-      dry_run: ${{ inputs.dry_run }}
-      hex_dry_run: ${{ inputs.hex_dry_run }}
-      skip_tests: false
+      operation: ${{ inputs.operation || 'auto' }}
+      tag_name: ${{ inputs.tag_name || '' }}
+      dry_run: ${{ inputs.dry_run || false }}
+      hex_dry_run: ${{ inputs.hex_dry_run || false }}
+      skip_tests: ${{ inputs.skip_tests || false }}
+      version_override: ${{ inputs.version_override || '' }}
     secrets: inherit

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,21 @@
+name: Jido Review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  review:
+    name: Jido Review
+    uses: agentjido/github-actions/.github/workflows/jido-review.yml@v4


### PR DESCRIPTION
## Summary
- replace legacy shared v3 CI and release callers with stock Jido workflows v4
- add the stock Jido Review workflow

## Validation
- ruby workflow YAML parse
- git diff --check
- actionlint
- stale shared workflow reference scan