### PR TITLE
feat(tracer): add scoped observe spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ OpenTelemetry extension for the Jido.Observe system.
 
 - Implements `Jido.Observe.Tracer` as `Jido.Otel.Tracer`
 - Converts Jido event prefixes to span names (`[:jido, :agent, :run]` -> `jido.agent.run`)
-- Maps Jido metadata and measurements to OpenTelemetry attributes
+- Sanitizes and maps Jido metadata and measurements to OpenTelemetry attributes
 - Records exceptions as OpenTelemetry exception events
 - Applies idempotent terminal span handling (`first_terminal_call_wins`)
+- Activates synchronous `Jido.Observe.with_span/3` spans as the current OTel span
+  for correctly parented nested instrumentation
 
 ## Installation
 
@@ -61,7 +63,8 @@ config :jido_otel,
   current_span_mode: :safe
 ```
 
-Use `Jido.Observe` spans as usual and they will be bridged to OpenTelemetry:
+Use `Jido.Observe` spans as usual and they will be bridged to OpenTelemetry.
+Synchronous `with_span/3` spans are activated only while the callback runs:
 
 ```elixir
 Jido.Observe.with_span([:jido, :agent, :action, :run], %{agent_id: "agent-1"}, fn ->
@@ -80,6 +83,9 @@ For exporting to an OTLP collector, set your preferred exporter config in your h
 - `:activate_unsafe`: preserves legacy same-process activation/restore behavior.
 
 For async `start_span`/`finish_span` flows across processes, use `:safe`.
+Synchronous `Jido.Observe.with_span/3` uses `with_span_scope/3`, which activates
+the span only in the caller process and restores the previous current span before
+returning.
 
 Terminal callbacks (`span_stop/2` and `span_exception/4`) are idempotent. When multiple terminal calls race, the first terminal call wins and later calls are no-op.
 

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -18,6 +18,7 @@ config :jido, :observability,
 - `Jido.Otel.Tracer.span_start/2`
 - `Jido.Otel.Tracer.span_stop/2`
 - `Jido.Otel.Tracer.span_exception/4`
+- `Jido.Otel.Tracer.with_span_scope/3` for synchronous `with_span/3` calls
 
 ## OpenTelemetry SDK Config
 
@@ -52,19 +53,35 @@ Valid values:
 
 If `:activate_unsafe` is enabled and `span_stop/2` or `span_exception/4` runs in another process, restore is skipped and a warning is logged.
 
+Synchronous `Jido.Observe.with_span/3` does not depend on `:activate_unsafe`.
+`Jido.Otel.Tracer.with_span_scope/3` activates the OTel span only while the
+callback runs in the caller process, which lets nested OTel instrumentation use
+the Jido span as its parent without leaking current-span context into async
+finish paths.
+
 ## Attribute Mapping Rules
 
-`Jido.Otel.Tracer` normalizes metadata and measurements into OpenTelemetry attributes:
+`Jido.Otel.Tracer` sanitizes metadata and measurements into OpenTelemetry attributes:
 
 - Atom keys become string keys (for example `:agent_id` -> `"agent_id"`).
 - Atom values become strings.
-- Homogeneous primitive lists remain lists.
-- Complex values are serialized via `inspect/2`.
+- Sensitive keys such as `:api_key`, `:authorization`, `:password`, `:secret`,
+  and `:token` are redacted.
+- Raw `:stacktrace` metadata is omitted from span attributes.
+- Long strings are truncated.
+- Homogeneous primitive lists remain bounded OTel-compatible lists.
+- Complex values are sanitized, bounded, made inspect-safe, and serialized via
+  `inspect/2`.
 
 Exception spans additionally include:
 
 - Span status `:error`
 - Exception event named `:exception`
 - Attributes `error.kind` and `error.reason`
+
+`jido_otel` is an adapter over Jido's canonical observe/telemetry surfaces. It
+does not define Jido runtime semantics privately; future metrics or event bridges
+should consume package telemetry rather than create a second instrumentation
+path.
 
 `Jido.Otel.Tracer` terminal callbacks are idempotent (`first_terminal_call_wins`): if `span_stop/2` and `span_exception/4` race for the same span context, only the first terminal call applies status/events and ends the span.

--- a/guides/quickstart.md
+++ b/guides/quickstart.md
@@ -50,6 +50,16 @@ Jido.Observe.with_span([:jido, :agent, :action, :run], %{agent_id: "agent-1"}, f
 end)
 ```
 
-The span name becomes `jido.agent.action.run` and metadata is attached as OpenTelemetry attributes.
+The span name becomes `jido.agent.action.run` and sanitized metadata is attached
+as OpenTelemetry attributes. While the callback runs, the Jido span is the
+current OpenTelemetry span, so nested OTel-aware libraries create child spans
+under it.
+
+Async lifecycle spans remain context-neutral:
+
+```elixir
+span_ctx = Jido.Observe.start_span([:jido, :agent, :async], %{agent_id: "agent-1"})
+Jido.Observe.finish_span(span_ctx)
+```
 
 Terminal span callbacks are idempotent (`first_terminal_call_wins`).

--- a/guides/upstream-alignment.md
+++ b/guides/upstream-alignment.md
@@ -1,6 +1,7 @@
-# Upstream Alignment Proposal (`jido`)
+# Upstream Alignment (`jido`)
 
-This document captures the proposed upstream coordination work for `Jido.Observe` and tracer adapters.
+This document captures the upstream coordination work for `Jido.Observe` and
+tracer adapters.
 
 ## Problem Statement
 
@@ -11,16 +12,20 @@ This document captures the proposed upstream coordination work for `Jido.Observe
 
 OpenTelemetry current span context is process-local. Tracer adapters that mutate current process span context in `span_start/2` can leak context when spans are finished in another process.
 
-## Proposed Upstream Changes
+## Upstream Changes
 
-1. Add a scoped callback path for synchronous span execution.
-2. Keep async callbacks explicit and context-neutral by default.
-3. Introduce optional behavior callbacks for adapters that need process-scoped activation semantics.
-4. Clarify process-local context constraints in `Jido.Observe` docs and examples.
+Implemented in `jido`:
 
-## Candidate API Direction
+1. `Jido.Observe.Tracer` exposes optional `with_span_scope/3`.
+2. `Jido.Observe.with_span/3` uses `with_span_scope/3` when the configured
+   tracer implements it.
+3. Async callbacks remain explicit and context-neutral by default.
+4. `Jido.Observe` documents process-local context constraints for sync versus
+   async spans.
 
-Example behavior extension (illustrative only):
+## Callback API
+
+Tracer behavior extension:
 
 ```elixir
 @callback with_span_scope(
@@ -32,22 +37,26 @@ Example behavior extension (illustrative only):
 
 Notes:
 
-- `with_span_scope/3` would be optional and used by `Jido.Observe.with_span/3` when implemented.
+- `with_span_scope/3` is optional and used by `Jido.Observe.with_span/3` when implemented.
 - Async `start_span/2` and finish callbacks remain unchanged and must not assume same-process completion.
 
-## Suggested Upstream Issue Draft
+## Adapter Guidance
 
-Title:
+`Jido.Otel.Tracer` implements `with_span_scope/3` by activating the OTel span
+only for the duration of the synchronous callback and restoring the previous
+current span before returning. This keeps nested same-process OTel
+instrumentation correctly parented while preserving safe async lifecycle behavior
+for `start_span/2` and terminal callbacks.
 
-`observe: add scoped tracer callback path for OTP-safe sync spans`
+Adapter implementations should:
 
-Body outline:
-
-1. Describe process-local OTel context and async finish caveat.
-2. Propose optional scoped callback to separate sync and async semantics.
-3. Keep existing callback compatibility, with defaults preserving current behavior.
-4. Add migration notes for adapter maintainers.
+1. Call the provided function in the caller process.
+2. Call the provided function exactly once.
+3. Preserve the function return value.
+4. Preserve exception, throw, and exit semantics.
+5. Keep async `span_start/2` context-neutral unless a caller explicitly opts into
+   unsafe same-process activation behavior.
 
 ## Status
 
-Opened upstream issue: [agentjido/jido#176](https://github.com/agentjido/jido/issues/176)
+Upstream issue: [agentjido/jido#176](https://github.com/agentjido/jido/issues/176)

--- a/lib/jido/otel/tracer.ex
+++ b/lib/jido/otel/tracer.ex
@@ -17,6 +17,22 @@ defmodule Jido.Otel.Tracer do
   @printable_limit 200
   @max_inspect_chars 512
   @max_stacktrace_chars 4_096
+  @max_sanitize_depth 4
+  @max_collection_items 20
+  @redacted "[REDACTED]"
+  @omitted "[OMITTED]"
+  @depth_limit "[DEPTH_LIMIT]"
+  @sensitive_key_parts MapSet.new(~w[
+    api_key
+    apikey
+    authorization
+    credential
+    credentials
+    password
+    private_key
+    secret
+    token
+  ])
 
   @typedoc """
   Controls whether `span_start/2` mutates process-local current span context.
@@ -65,17 +81,8 @@ defmodule Jido.Otel.Tracer do
   @spec span_start(Jido.Observe.Tracer.event_prefix(), Jido.Observe.Tracer.metadata()) :: tracer_ctx()
   def span_start(event_prefix, metadata) when is_list(event_prefix) and is_map(metadata) do
     mode = current_span_mode()
-    span_name = event_prefix_to_name(event_prefix)
     previous_span_ctx = maybe_capture_previous_span(mode)
-
-    span_ctx =
-      Tracer.start_span(
-        span_name,
-        %{
-          kind: :internal,
-          attributes: normalize_attributes(metadata)
-        }
-      )
+    span_ctx = start_otel_span(event_prefix, metadata)
 
     _ = maybe_activate_span(mode, span_ctx)
 
@@ -119,6 +126,57 @@ defmodule Jido.Otel.Tracer do
     end)
   end
 
+  @doc """
+  Runs synchronous work inside an active OpenTelemetry span.
+
+  This callback is used by `Jido.Observe.with_span/3` when available. Unlike
+  async `span_start/2`, scoped spans intentionally activate the OTel span only
+  for the duration of the provided function and restore the previous current
+  span before returning.
+  """
+  @impl true
+  @spec with_span_scope(
+          Jido.Observe.Tracer.event_prefix(),
+          Jido.Observe.Tracer.metadata(),
+          (-> result)
+        ) :: result
+        when result: term()
+  def with_span_scope(event_prefix, metadata, fun)
+      when is_list(event_prefix) and is_map(metadata) and is_function(fun, 0) do
+    previous_span_ctx = Tracer.current_span_ctx()
+    span_ctx = start_otel_span(event_prefix, metadata)
+
+    _ = Tracer.set_current_span(span_ctx)
+
+    try do
+      result = fun.()
+      _ = :otel_span.set_status(span_ctx, :ok)
+      result
+    rescue
+      exception ->
+        stacktrace = __STACKTRACE__
+        _ = mark_scoped_exception(span_ctx, :error, exception, stacktrace)
+        reraise exception, stacktrace
+    catch
+      kind, reason ->
+        stacktrace = __STACKTRACE__
+        _ = mark_scoped_exception(span_ctx, kind, reason, stacktrace)
+        :erlang.raise(kind, reason, stacktrace)
+    after
+      end_scoped_span(span_ctx, previous_span_ctx)
+    end
+  end
+
+  defp start_otel_span(event_prefix, metadata) do
+    Tracer.start_span(
+      event_prefix_to_name(event_prefix),
+      %{
+        kind: :internal,
+        attributes: sanitize_attributes(metadata)
+      }
+    )
+  end
+
   defp finalize_span(%Context{} = tracer_ctx, status, terminal_callback)
        when is_function(terminal_callback, 1) do
     if claim_terminal?(tracer_ctx.terminal_guard) do
@@ -151,10 +209,10 @@ defmodule Jido.Otel.Tracer do
          mode: :activate_unsafe,
          started_by: started_by
        }) do
-    Logger.warning(
+    Logger.warning(fn ->
       "Jido.Otel.Tracer received terminal callback in #{inspect(self())} for a span started by " <>
         "#{inspect(started_by)} while current_span_mode is :activate_unsafe; skipping span-context restore"
-    )
+    end)
 
     :ok
   end
@@ -170,7 +228,9 @@ defmodule Jido.Otel.Tracer do
         :activate_unsafe
 
       invalid ->
-        Logger.warning("Invalid :jido_otel current_span_mode #{inspect(invalid)}. Falling back to :safe")
+        Logger.warning(fn ->
+          "Invalid :jido_otel current_span_mode #{inspect(invalid)}. Falling back to :safe"
+        end)
 
         :safe
     end
@@ -190,7 +250,9 @@ defmodule Jido.Otel.Tracer do
     terminal_callback.(span_ctx)
   rescue
     exception ->
-      Logger.warning("Jido.Otel.Tracer terminal callback failed: #{Exception.message(exception)}")
+      Logger.warning(fn ->
+        "Jido.Otel.Tracer terminal callback failed: #{Exception.message(exception)}"
+      end)
 
       :ok
   end
@@ -210,10 +272,11 @@ defmodule Jido.Otel.Tracer do
         Span.add_event(
           span_ctx,
           :exception,
-          normalize_attributes(%{
-            kind: kind,
-            reason: reason,
-            stacktrace: truncate_string(Exception.format_stacktrace(stacktrace), @max_stacktrace_chars)
+          sanitize_attributes(%{
+            "exception.type" => kind,
+            "exception.message" => reason,
+            "exception.stacktrace" => truncate_string(Exception.format_stacktrace(stacktrace), @max_stacktrace_chars),
+            "jido.error.kind" => kind
           })
         )
     end
@@ -221,8 +284,27 @@ defmodule Jido.Otel.Tracer do
     :ok
   end
 
+  defp mark_scoped_exception(span_ctx, kind, reason, stacktrace) do
+    _ = record_span_exception(span_ctx, kind, reason, stacktrace)
+
+    _ =
+      maybe_set_attributes(span_ctx, %{
+        "error.kind" => kind,
+        "error.reason" => reason
+      })
+
+    _ = :otel_span.set_status(span_ctx, :error)
+    :ok
+  end
+
+  defp end_scoped_span(span_ctx, previous_span_ctx) do
+    _ = Span.end_span(span_ctx)
+  after
+    _ = Tracer.set_current_span(previous_span_ctx)
+  end
+
   defp maybe_set_attributes(span_ctx, attributes) when is_map(attributes) do
-    normalized_attributes = normalize_attributes(attributes)
+    normalized_attributes = sanitize_attributes(attributes)
 
     if map_size(normalized_attributes) > 0 do
       _ = Span.set_attributes(span_ctx, normalized_attributes)
@@ -240,52 +322,148 @@ defmodule Jido.Otel.Tracer do
   defp normalize_event_segment(segment) when is_binary(segment), do: segment
   defp normalize_event_segment(segment), do: safe_inspect(segment, 20, 80)
 
-  defp normalize_attributes(attributes) do
+  defp sanitize_attributes(attributes) do
     Enum.reduce(attributes, %{}, fn {key, value}, acc ->
-      Map.put(acc, normalize_key(key), normalize_value(value))
+      sanitized_key = sanitize_attribute_key(key)
+      Map.put(acc, sanitized_key, sanitize_attribute_value(sanitized_key, value))
     end)
   end
 
-  defp normalize_key(key) when is_binary(key), do: key
-  defp normalize_key(key) when is_atom(key), do: Atom.to_string(key)
-  defp normalize_key(key), do: safe_inspect(key)
+  defp sanitize_attribute_key(key) when is_binary(key), do: key
+  defp sanitize_attribute_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp sanitize_attribute_key(key), do: safe_inspect(key)
 
-  defp normalize_value(value)
-       when is_binary(value) or is_boolean(value) or is_integer(value) or is_float(value),
-       do: value
-
-  defp normalize_value(value) when is_atom(value), do: Atom.to_string(value)
-
-  defp normalize_value([]), do: []
-
-  defp normalize_value(value) when is_list(value) do
+  defp sanitize_attribute_value(key, value) when is_binary(key) do
     cond do
-      Enum.all?(value, &is_binary/1) ->
-        value
-
-      Enum.all?(value, &is_boolean/1) ->
-        value
-
-      Enum.all?(value, &is_integer/1) ->
-        value
-
-      Enum.all?(value, &is_float/1) ->
-        value
-
-      Enum.all?(value, &is_atom/1) ->
-        Enum.map(value, &Atom.to_string/1)
-
-      true ->
-        safe_inspect(value)
+      sensitive_attribute_key?(key) -> @redacted
+      raw_stacktrace_attribute_key?(key) -> @omitted
+      true -> sanitize_attribute_value(value)
     end
   end
 
-  defp normalize_value(value), do: safe_inspect(value)
+  defp sanitize_attribute_value(value) when is_binary(value),
+    do: truncate_string(value, @max_inspect_chars)
+
+  defp sanitize_attribute_value(value)
+       when is_boolean(value) or is_integer(value) or is_float(value),
+       do: value
+
+  defp sanitize_attribute_value(value) when is_atom(value), do: Atom.to_string(value)
+
+  defp sanitize_attribute_value([]), do: []
+
+  defp sanitize_attribute_value(value) when is_list(value) do
+    cond do
+      Enum.all?(value, &is_binary/1) ->
+        value
+        |> Enum.take(@max_collection_items)
+        |> Enum.map(&truncate_string(&1, @max_inspect_chars))
+
+      Enum.all?(value, &is_boolean/1) ->
+        Enum.take(value, @max_collection_items)
+
+      Enum.all?(value, &is_integer/1) ->
+        Enum.take(value, @max_collection_items)
+
+      Enum.all?(value, &is_float/1) ->
+        Enum.take(value, @max_collection_items)
+
+      Enum.all?(value, &is_atom/1) ->
+        value
+        |> Enum.take(@max_collection_items)
+        |> Enum.map(&Atom.to_string/1)
+
+      true ->
+        safe_inspect(sanitize_for_inspect(value))
+    end
+  end
+
+  defp sanitize_attribute_value(value) do
+    if is_exception(value) do
+      value
+      |> Exception.message()
+      |> truncate_string(@max_inspect_chars)
+    else
+      safe_inspect(sanitize_for_inspect(value))
+    end
+  end
+
+  defp sensitive_attribute_key?(key) do
+    normalized_key = String.downcase(key)
+
+    MapSet.member?(@sensitive_key_parts, normalized_key) ||
+      normalized_key |> key_parts() |> Enum.any?(&MapSet.member?(@sensitive_key_parts, &1))
+  end
+
+  defp raw_stacktrace_attribute_key?(key) do
+    key
+    |> String.downcase()
+    |> Kernel.==("stacktrace")
+  end
+
+  defp key_parts(key), do: String.split(key, ~r/[^a-z0-9]+/, trim: true)
+
+  defp sanitize_for_inspect(value, depth \\ @max_sanitize_depth)
+  defp sanitize_for_inspect(_value, 0), do: @depth_limit
+
+  defp sanitize_for_inspect(%_{} = value, depth) do
+    value
+    |> Map.from_struct()
+    |> Map.put(:__struct__, value.__struct__)
+    |> sanitize_for_inspect(depth - 1)
+  rescue
+    _ -> inspect_fallback(value)
+  end
+
+  defp sanitize_for_inspect(value, depth) when is_map(value) do
+    value
+    |> Enum.take(@max_collection_items)
+    |> Map.new(fn {key, nested_value} ->
+      sanitized_key = sanitize_attribute_key(key)
+
+      nested_value =
+        if sensitive_attribute_key?(sanitized_key) do
+          @redacted
+        else
+          sanitize_for_inspect(nested_value, depth - 1)
+        end
+
+      {key, nested_value}
+    end)
+  end
+
+  defp sanitize_for_inspect(value, depth) when is_list(value) do
+    value
+    |> Enum.take(@max_collection_items)
+    |> Enum.map(&sanitize_for_inspect(&1, depth - 1))
+  end
+
+  defp sanitize_for_inspect(value, depth) when is_tuple(value) do
+    value
+    |> Tuple.to_list()
+    |> Enum.take(@max_collection_items)
+    |> Enum.map(&sanitize_for_inspect(&1, depth - 1))
+    |> List.to_tuple()
+  end
+
+  defp sanitize_for_inspect(value, _depth), do: value
 
   defp safe_inspect(value, limit \\ @inspect_limit, printable_limit \\ @printable_limit) do
     value
     |> inspect(limit: limit, printable_limit: printable_limit)
     |> truncate_string(@max_inspect_chars)
+  rescue
+    _ -> inspect_fallback(value)
+  end
+
+  defp inspect_fallback(value) do
+    module =
+      case value do
+        %{__struct__: struct} when is_atom(struct) -> inspect(struct)
+        _ -> value |> :erlang.term_to_binary() |> byte_size() |> then(&"#{&1} bytes")
+      end
+
+    "#Inspect.Error<#{module}>"
   end
 
   defp truncate_string(value, max_chars) when is_binary(value) do

--- a/lib/jido/otel/tracer.ex
+++ b/lib/jido/otel/tracer.ex
@@ -409,7 +409,7 @@ defmodule Jido.Otel.Tracer do
   defp sanitize_for_inspect(%_{} = value, depth) do
     value
     |> Map.from_struct()
-    |> Map.put(:__struct__, value.__struct__)
+    |> Map.put("__struct__", value.__struct__)
     |> sanitize_for_inspect(depth - 1)
   rescue
     _ -> inspect_fallback(value)
@@ -451,10 +451,14 @@ defmodule Jido.Otel.Tracer do
   defp safe_inspect(value, limit \\ @inspect_limit, printable_limit \\ @printable_limit) do
     value
     |> inspect(limit: limit, printable_limit: printable_limit)
+    |> reject_inspect_error(value)
     |> truncate_string(@max_inspect_chars)
   rescue
     _ -> inspect_fallback(value)
   end
+
+  defp reject_inspect_error("#Inspect.Error<" <> _rest, value), do: inspect_fallback(value)
+  defp reject_inspect_error(inspected, _value), do: inspected
 
   defp inspect_fallback(value) do
     module =

--- a/test/jido/otel/tracer_test.exs
+++ b/test/jido/otel/tracer_test.exs
@@ -15,20 +15,17 @@ defmodule Jido.Otel.TracerTest do
   setup do
     {:ok, _apps} = Application.ensure_all_started(:opentelemetry)
     previous_span_mode = Application.get_env(:jido_otel, :current_span_mode, :__missing__)
+    test_pid = self()
 
     Application.put_env(:jido_otel, :current_span_mode, :safe)
-
-    if Process.whereis(:otel_test_exporter) != nil do
-      raise "otel test exporter is already registered"
-    end
-
-    true = Process.register(self(), :otel_test_exporter)
+    wait_for_exporter_release(test_pid)
+    true = Process.register(test_pid, :otel_test_exporter)
     flush_exported_spans()
 
     on_exit(fn ->
       restore_env(:jido_otel, :current_span_mode, previous_span_mode)
 
-      if Process.whereis(:otel_test_exporter) == self() do
+      if Process.whereis(:otel_test_exporter) == test_pid do
         Process.unregister(:otel_test_exporter)
       end
     end)
@@ -150,7 +147,13 @@ defmodule Jido.Otel.TracerTest do
         stacktrace: [{__MODULE__, :test, 0, []}],
         message: long_value,
         labels: Enum.map(1..30, &"label-#{&1}"),
-        details: %{token: "nested-secret", payload: long_value}
+        details: %{
+          token: "nested-secret",
+          payload: long_value,
+          deep: %{one: %{two: %{three: %{four: "hidden"}}}}
+        },
+        tuple: {:ok, %{token: "tuple-secret"}},
+        struct: %Jido.Otel.UnsafeInspect{value: "struct-value"}
       })
 
     assert :ok = Tracer.span_stop(tracer_ctx, %{})
@@ -165,7 +168,24 @@ defmodule Jido.Otel.TracerTest do
     assert length(attributes["labels"]) == 20
     refute "label-21" in attributes["labels"]
     assert attributes["details"] =~ "[REDACTED]"
+    assert attributes["details"] =~ "[DEPTH_LIMIT]"
     refute attributes["details"] =~ "nested-secret"
+    assert attributes["tuple"] =~ "[REDACTED]"
+    refute attributes["tuple"] =~ "tuple-secret"
+    assert attributes["struct"] =~ "Jido.Otel.UnsafeInspect"
+    assert attributes["struct"] =~ "struct-value"
+  end
+
+  test "falls back safely when event prefix segments cannot be inspected" do
+    tracer_ctx = Tracer.span_start([:jido, %Jido.Otel.UnsafeInspect{value: :unsafe}], %{})
+    assert :ok = Tracer.span_stop(tracer_ctx, %{})
+
+    exported_span = assert_exported_span()
+
+    span_name = span(exported_span, :name)
+
+    assert String.contains?(span_name, "#Inspect.Error<Jido.Otel.UnsafeInspect>")
+    refute String.contains?(span_name, "inspect failed")
   end
 
   test "safe mode does not leak caller current span across async finish" do
@@ -352,6 +372,36 @@ defmodule Jido.Otel.TracerTest do
     assert Enum.any?(span_events(exported_span), &(event(&1, :name) == :exception))
   end
 
+  test "with_span_scope preserves throws while recording an errored span" do
+    before_span_ctx = OTelTracer.current_span_ctx()
+
+    assert catch_throw(
+             Tracer.with_span_scope([:jido, :scope, :throw], %{}, fn ->
+               throw(:scoped_throw)
+             end)
+           ) == :scoped_throw
+
+    assert before_span_ctx == OTelTracer.current_span_ctx()
+
+    exported_span = assert_exported_span()
+
+    assert span(name: "jido.scope.throw") = exported_span
+    assert status(code: :error) = span(exported_span, :status)
+    assert span_attributes(exported_span)["error.kind"] == "throw"
+
+    exception_event = Enum.find(span_events(exported_span), &(event(&1, :name) == :exception))
+    assert exception_event != nil
+
+    event_attributes =
+      exception_event
+      |> event(:attributes)
+      |> :otel_attributes.map()
+
+    assert get_event_attr(event_attributes, "exception.type") == "throw"
+    assert get_event_attr(event_attributes, "exception.message") == "scoped_throw"
+    assert is_binary(get_event_attr(event_attributes, "exception.stacktrace"))
+  end
+
   test "span_stop and span_exception ignore invalid tracer contexts" do
     assert :ok = Tracer.span_stop(:invalid_ctx, %{duration: 1})
     assert :ok = Tracer.span_exception(:invalid_ctx, :error, :boom, [])
@@ -518,6 +568,28 @@ defmodule Jido.Otel.TracerTest do
       {:span, _span} -> flush_exported_spans()
     after
       0 -> :ok
+    end
+  end
+
+  defp wait_for_exporter_release(test_pid) do
+    case Process.whereis(:otel_test_exporter) do
+      nil ->
+        :ok
+
+      ^test_pid ->
+        Process.unregister(:otel_test_exporter)
+
+      exporter_pid ->
+        ref = Process.monitor(exporter_pid)
+
+        receive do
+          {:DOWN, ^ref, :process, ^exporter_pid, _reason} ->
+            :ok
+        after
+          1_000 ->
+            Process.demonitor(ref, [:flush])
+            raise "otel test exporter is already registered by #{inspect(exporter_pid)}"
+        end
     end
   end
 

--- a/test/jido/otel/tracer_test.exs
+++ b/test/jido/otel/tracer_test.exs
@@ -140,6 +140,34 @@ defmodule Jido.Otel.TracerTest do
     assert span(name: "jido.agent.42") = assert_exported_span()
   end
 
+  test "sanitizes sensitive, stacktrace, and high-cardinality span attributes" do
+    long_value = String.duplicate("x", 700)
+
+    tracer_ctx =
+      Tracer.span_start([:jido, :agent, :sanitize], %{
+        api_key: "secret-api-key",
+        authorization: "Bearer secret-token",
+        stacktrace: [{__MODULE__, :test, 0, []}],
+        message: long_value,
+        labels: Enum.map(1..30, &"label-#{&1}"),
+        details: %{token: "nested-secret", payload: long_value}
+      })
+
+    assert :ok = Tracer.span_stop(tracer_ctx, %{})
+
+    attributes = assert_exported_span() |> span_attributes()
+
+    assert attributes["api_key"] == "[REDACTED]"
+    assert attributes["authorization"] == "[REDACTED]"
+    assert attributes["stacktrace"] == "[OMITTED]"
+    assert attributes["message"] =~ "(truncated)"
+    assert String.length(attributes["message"]) < 600
+    assert length(attributes["labels"]) == 20
+    refute "label-21" in attributes["labels"]
+    assert attributes["details"] =~ "[REDACTED]"
+    refute attributes["details"] =~ "nested-secret"
+  end
+
   test "safe mode does not leak caller current span across async finish" do
     before_span_ctx = OTelTracer.current_span_ctx()
     tracer_ctx = Tracer.span_start([:jido, :agent, :async_safe], %{})
@@ -276,6 +304,54 @@ defmodule Jido.Otel.TracerTest do
     Process.exit(foreign_pid, :kill)
   end
 
+  test "with_span_scope activates a sync parent span and restores caller context" do
+    before_span_ctx = OTelTracer.current_span_ctx()
+
+    result =
+      Tracer.with_span_scope([:jido, :scope, :parent], %{component: :test}, fn ->
+        parent_span_ctx = OTelTracer.current_span_ctx()
+        refute parent_span_ctx == before_span_ctx
+
+        child_span_ctx =
+          OTelTracer.start_span("jido.scope.child", %{attributes: %{child: true}})
+
+        OpenTelemetry.Span.end_span(child_span_ctx)
+
+        assert parent_span_ctx == OTelTracer.current_span_ctx()
+        :scoped_result
+      end)
+
+    assert result == :scoped_result
+    assert before_span_ctx == OTelTracer.current_span_ctx()
+
+    exported_spans = collect_exported_spans(1_000)
+    parent_span = span_by_name(exported_spans, "jido.scope.parent")
+    child_span = span_by_name(exported_spans, "jido.scope.child")
+
+    assert status(code: :ok) = span(parent_span, :status)
+    assert span(child_span, :trace_id) == span(parent_span, :trace_id)
+    assert span(child_span, :parent_span_id) == span(parent_span, :span_id)
+  end
+
+  test "with_span_scope records escaped exceptions and restores caller context" do
+    before_span_ctx = OTelTracer.current_span_ctx()
+
+    assert_raise RuntimeError, "scoped failure", fn ->
+      Tracer.with_span_scope([:jido, :scope, :failure], %{}, fn ->
+        raise "scoped failure"
+      end)
+    end
+
+    assert before_span_ctx == OTelTracer.current_span_ctx()
+
+    exported_span = assert_exported_span()
+
+    assert span(name: "jido.scope.failure") = exported_span
+    assert status(code: :error) = span(exported_span, :status)
+    assert span_attributes(exported_span)["error.kind"] == "error"
+    assert Enum.any?(span_events(exported_span), &(event(&1, :name) == :exception))
+  end
+
   test "span_stop and span_exception ignore invalid tracer contexts" do
     assert :ok = Tracer.span_stop(:invalid_ctx, %{duration: 1})
     assert :ok = Tracer.span_exception(:invalid_ctx, :error, :boom, [])
@@ -340,6 +416,42 @@ defmodule Jido.Otel.TracerTest do
     assert span_attributes(exported_span)["duration"] == 42
   end
 
+  test "Jido.Observe.with_span uses scoped callback for nested OpenTelemetry spans" do
+    previous_observability = Application.get_env(:jido, :observability, [])
+    before_span_ctx = OTelTracer.current_span_ctx()
+
+    Application.put_env(
+      :jido,
+      :observability,
+      Keyword.put(previous_observability, :tracer, Tracer)
+    )
+
+    on_exit(fn ->
+      Application.put_env(:jido, :observability, previous_observability)
+    end)
+
+    assert :ok =
+             Jido.Observe.with_span([:jido, :observe, :scoped], %{component: :test}, fn ->
+               child_span_ctx =
+                 OTelTracer.start_span("jido.observe.scoped.child", %{
+                   attributes: %{child: true}
+                 })
+
+               OpenTelemetry.Span.end_span(child_span_ctx)
+               :ok
+             end)
+
+    assert before_span_ctx == OTelTracer.current_span_ctx()
+
+    exported_spans = collect_exported_spans(1_000)
+    parent_span = span_by_name(exported_spans, "jido.observe.scoped")
+    child_span = span_by_name(exported_spans, "jido.observe.scoped.child")
+
+    assert status(code: :ok) = span(parent_span, :status)
+    assert span(child_span, :trace_id) == span(parent_span, :trace_id)
+    assert span(child_span, :parent_span_id) == span(parent_span, :span_id)
+  end
+
   defp assert_exported_span do
     assert_receive {:span, exported_span}, 1_000
     exported_span
@@ -374,6 +486,14 @@ defmodule Jido.Otel.TracerTest do
     exported_span
     |> span(:events)
     |> :otel_events.list()
+  end
+
+  defp span_by_name(exported_spans, name) do
+    Enum.find(exported_spans, &(span(&1, :name) == name)) ||
+      flunk(
+        "expected exported span named #{inspect(name)}, " <>
+          "got #{inspect(Enum.map(exported_spans, &span(&1, :name)))}"
+      )
   end
 
   defp get_event_attr(event_attributes, key) do

--- a/test/support/unsafe_inspect.ex
+++ b/test/support/unsafe_inspect.ex
@@ -1,0 +1,9 @@
+defmodule Jido.Otel.UnsafeInspect do
+  @moduledoc false
+
+  defstruct [:value]
+end
+
+defimpl Inspect, for: Jido.Otel.UnsafeInspect do
+  def inspect(_value, _opts), do: raise("inspect failed")
+end


### PR DESCRIPTION
## Summary
- implement `Jido.Otel.Tracer.with_span_scope/3` for synchronous `Jido.Observe.with_span/3` integration
- activate OTel context only for scoped callback execution, restore caller context, and preserve exception/throw/exit behavior
- harden span attribute sanitization with redaction, truncation, raw stacktrace omission, bounded collections, and inspect-safe complex values
- update README, guides, and tests for the official adapter role and standards alignment

## Verification
- `mix quality`
- `mix test`

Refs #14